### PR TITLE
Also passing 'display' value next to the latest values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,11 @@ Changelog of lizard-efcis
 
 - Added proper logging to ftp import task.
 
+- Tweak for the map. Pass an extra 'display_values' list. The display value is
+  the same as the latest value except when it is a KRW score. Then it is the
+  actual 'raw' krw value ('0.337') instead of the value of the middle of the
+  krw range ('0.3').
+
 
 0.1 (2015-03-09)
 ----------------

--- a/lizard_efcis/serializers.py
+++ b/lizard_efcis/serializers.py
@@ -290,6 +290,7 @@ class MapSerializer(gis_serializers.GeoFeatureModelSerializer):
     color_value = serializers.SerializerMethodField()
     abs_color_value = serializers.SerializerMethodField()
     latest_value = serializers.SerializerMethodField()
+    latest_display_value = serializers.SerializerMethodField()
     latest_krw_value = serializers.SerializerMethodField()
     latest_datetime = serializers.SerializerMethodField()
     boxplot_data = serializers.SerializerMethodField()
@@ -312,6 +313,9 @@ class MapSerializer(gis_serializers.GeoFeatureModelSerializer):
 
     def get_latest_value(self, obj):
         return self.context['latest_values'].get(obj.id)
+
+    def get_latest_display_value(self, obj):
+        return self.context['latest_display_values'].get(obj.id)
 
     def get_latest_krw_value(self, obj):
         return self.context['latest_krw_values'].get(obj.id)


### PR DESCRIPTION
The display value is the same as the latest value except when it is a KRW
score. Then it is the actual 'raw' krw value ('0.337') instead of the value of
the middle of the krw range ('0.3').